### PR TITLE
Bulk-write upserts in batched pymongo calls; add --report-mode flag (closes #10)

### DIFF
--- a/src/ontology_loader/cli.py
+++ b/src/ontology_loader/cli.py
@@ -14,24 +14,32 @@ logger = logging.getLogger(__name__)
 @click.option("--source-ontology", default="envo", help="Lowercase ontology prefix, e.g., envo, go, uberon, etc.")
 @click.option("--output-directory", default=None, help="Output directory for reporting, default is /tmp")
 @click.option("--generate-reports", default=True, help="Generate reports")
-def cli(source_ontology, output_directory, generate_reports):
+@click.option(
+    "--report-mode",
+    type=click.Choice(["compared", "upsert", "off"], case_sensitive=False),
+    default="compared",
+    show_default=True,
+    help=(
+        "How upsert reports are produced. "
+        "'compared' batches a pre-read and only reports docs that actually changed (preserves prior fidelity); "
+        "'upsert' skips the pre-read and reports every existing doc as updated (max throughput); "
+        "'off' suppresses report tracking entirely (lowest memory)."
+    ),
+)
+def cli(source_ontology, output_directory, generate_reports, report_mode):
     """
     CLI entry point for the ontology loader.
-
-    :param source_ontology: Lowercase ontology prefix, e.g., envo, go, uberon, etc.
-    :param output_directory: Output directory for reporting, default is /tmp
-    :param generate_reports: Generate reports or not, default is True
 
     Set the parameters for the connection to mongodb in the environment variables MONGO_HOST, MONGO_PORT,
     MONGO_USER, MONGO_PASSWORD, MONGO_DB.
     """
     logger.info(f"Processing ontology: {source_ontology}")
 
-    # Initialize the MongoDB Loader
     loader = OntologyLoaderController(
         source_ontology=source_ontology,
         output_directory=output_directory,
         generate_reports=generate_reports,
+        report_mode=report_mode,
     )
     loader.run_ontology_loader()
 

--- a/src/ontology_loader/mongodb_loader.py
+++ b/src/ontology_loader/mongodb_loader.py
@@ -7,6 +7,8 @@ from typing import List, Optional
 from linkml_runtime import SchemaView
 from linkml_store import Client
 from nmdc_schema.nmdc import OntologyClass, OntologyRelation
+from pymongo import MongoClient as PyMongoClient
+from pymongo import UpdateOne
 
 from ontology_loader.mongo_db_config import MongoDBConfig
 from ontology_loader.reporter import Report
@@ -15,13 +17,21 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(
 logger = logging.getLogger(__name__)
 
 
+# Default batch size for `bulk_write` calls. Larger batches are faster up to
+# pymongo's server-side ~100k op limit, but cost memory per batch.
+DEFAULT_BULK_BATCH_SIZE = 1000
+
+
+VALID_REPORT_MODES = ("compared", "upsert", "off")
+
+
 def _handle_obsolete_terms(obsolete_terms, class_collection, relation_collection):
     """
     Handle obsolete ontology terms by updating their status and removing relations.
 
-    :param obsolete_terms: List of obsolete term IDs
-    :param class_collection: MongoDB collection for classes
-    :param relation_collection: MongoDB collection for relations
+    Uses the linkml_store collection API. The obsolete subset is always small
+    enough that per-item work is cheap; this path is unchanged from the
+    pre-bulk-write implementation.
     """
     if not obsolete_terms:
         return
@@ -43,77 +53,141 @@ def _handle_obsolete_terms(obsolete_terms, class_collection, relation_collection
     logging.debug("Removed relations referencing obsolete terms.")
 
 
-def _upsert_relation(relation, collection):
-    """
-    Upsert a single relation and return report data if valid.
+def _class_to_doc(obj):
+    """Convert an OntologyClass dataclass to a dict with required boolean defaults."""
+    doc = asdict(obj)
+    if doc.get("is_root") is None:
+        doc["is_root"] = False
+    if doc.get("is_obsolete") is None:
+        doc["is_obsolete"] = False
+    return doc
 
-    :param relation: OntologyRelation object to upsert
-    :param collection: MongoDB collection for relations
-    :return: List with relation data or None if invalid
-    """
+
+def _normalize_relation(relation):
+    """Normalize an OntologyRelation (dataclass or dict) to a dict; return None if invalid."""
     if type(relation) is OntologyRelation:
         relation = asdict(relation)
-
     if not relation.get("subject") or not relation.get("predicate") or not relation.get("object"):
         logging.warning(f"Skipping invalid relation: {relation}")
         return None
-
-    # Get all relation fields to use as update_fields
-    update_fields = list(relation.keys())
-    collection.upsert([relation], filter_fields=["subject", "predicate", "object"], update_fields=update_fields)
-    logging.debug(f"Inserted OntologyRelation: {relation}")
-    return [relation.get("subject"), relation.get("predicate"), relation.get("object")]
+    return relation
 
 
-def _upsert_ontology_class(obj, collection, ontology_fields):
+def _bulk_upsert_classes(
+    py_collection,
+    ontology_classes,
+    ontology_fields,
+    report_mode,
+    batch_size=DEFAULT_BULK_BATCH_SIZE,
+):
     """
-    Upsert a single ontology class and return update report data.
+    Bulk-upsert OntologyClass documents.
 
-    :param obj: OntologyClass object to upsert
-    :param collection: MongoDB collection for classes
-    :param ontology_fields: List of field names for OntologyClass
-    :return: Tuple of (was_updated, report_row)
+    Returns (insertions_report, updates_report) — both lists of report rows.
+
+    `report_mode` semantics:
+        - 'compared': one pre-read per batch (find with $in), only write+report
+          docs that are new or whose fields actually changed. Preserves the
+          pre-bulk-write behavior modulo per-doc → per-batch read.
+        - 'upsert': skip the pre-read; bulk_write every doc. New docs
+          (BulkWriteResult.upserted_ids) go to inserts, the rest to updates.
+        - 'off': bulk_write every doc; do not track reports.
     """
-    filter_criteria = {"id": obj.id}
-    query_result = collection.find(filter_criteria)
-    existing_doc = query_result.rows[0] if query_result.num_rows > 0 else None
-    report_row = [obj.id] + [getattr(obj, field, "") for field in ontology_fields]
+    insertions_report: list = []
+    updates_report: list = []
 
-    if existing_doc:
-        updated_fields = {
-            key: getattr(obj, key) for key in ontology_fields if getattr(obj, key) != existing_doc.get(key)
-        }
-        if updated_fields:
-            collection.upsert([asdict(obj)], filter_fields=["id"], update_fields=list(updated_fields.keys()))
-            logging.debug(f"Updated OntologyClass (id={obj.id}): {updated_fields}")
-            return True, report_row
-    else:
-        # Ensure boolean fields are explicitly set to avoid null values in MongoDB
-        doc = asdict(obj)
-        if doc.get("is_root") is None:
-            doc["is_root"] = False
-        if doc.get("is_obsolete") is None:
-            doc["is_obsolete"] = False
+    for batch_start in range(0, len(ontology_classes), batch_size):
+        batch = ontology_classes[batch_start : batch_start + batch_size]
+        if not batch:
+            continue
 
-        collection.upsert([doc], filter_fields=["id"], update_fields=ontology_fields)
-        logging.debug(f"Inserted OntologyClass (id={obj.id}).")
-        return False, report_row
+        if report_mode == "compared":
+            ids = [obj.id for obj in batch]
+            existing = {doc["id"]: doc for doc in py_collection.find({"id": {"$in": ids}})}
+            ops = []
+            classification: list = []
+            for obj in batch:
+                doc = _class_to_doc(obj)
+                row = [obj.id] + [getattr(obj, field, "") for field in ontology_fields]
+                existing_doc = existing.get(obj.id)
+                if existing_doc is None:
+                    ops.append(UpdateOne({"id": obj.id}, {"$set": doc}, upsert=True))
+                    classification.append(("insert", row))
+                else:
+                    changed = any(doc.get(f) != existing_doc.get(f) for f in ontology_fields)
+                    if changed:
+                        ops.append(UpdateOne({"id": obj.id}, {"$set": doc}, upsert=True))
+                        classification.append(("update", row))
+            if ops:
+                py_collection.bulk_write(ops, ordered=False)
+                for kind, row in classification:
+                    (insertions_report if kind == "insert" else updates_report).append(row)
 
-    return None, None
+        elif report_mode == "upsert":
+            ops = []
+            rows = []
+            for obj in batch:
+                ops.append(UpdateOne({"id": obj.id}, {"$set": _class_to_doc(obj)}, upsert=True))
+                rows.append([obj.id] + [getattr(obj, field, "") for field in ontology_fields])
+            result = py_collection.bulk_write(ops, ordered=False)
+            upserted_idx = set(result.upserted_ids.keys()) if result.upserted_ids else set()
+            for i, row in enumerate(rows):
+                (insertions_report if i in upserted_idx else updates_report).append(row)
+
+        else:  # "off"
+            ops = [UpdateOne({"id": obj.id}, {"$set": _class_to_doc(obj)}, upsert=True) for obj in batch]
+            py_collection.bulk_write(ops, ordered=False)
+
+    return insertions_report, updates_report
+
+
+def _bulk_upsert_relations(
+    py_collection,
+    ontology_relations,
+    report_mode,
+    batch_size=DEFAULT_BULK_BATCH_SIZE,
+):
+    """
+    Bulk-upsert OntologyRelation documents.
+
+    Returns the insertions report (newly inserted relations only, or empty
+    when `report_mode='off'`). Updates of existing relations are not reported
+    here — relations are immutable in the loader's current model.
+    """
+    insertions_report: list = []
+    track = report_mode in ("compared", "upsert")
+
+    for batch_start in range(0, len(ontology_relations), batch_size):
+        batch = ontology_relations[batch_start : batch_start + batch_size]
+        ops = []
+        rows = []
+        for relation in batch:
+            d = _normalize_relation(relation)
+            if d is None:
+                continue
+            ops.append(
+                UpdateOne(
+                    {"subject": d["subject"], "predicate": d["predicate"], "object": d["object"]},
+                    {"$set": d},
+                    upsert=True,
+                )
+            )
+            if track:
+                rows.append([d["subject"], d["predicate"], d["object"]])
+        if not ops:
+            continue
+        result = py_collection.bulk_write(ops, ordered=False)
+        if track:
+            upserted_idx = set(result.upserted_ids.keys()) if result.upserted_ids else set()
+            for i, row in enumerate(rows):
+                if i in upserted_idx:
+                    insertions_report.append(row)
+
+    return insertions_report
 
 
 def get_mongo_connection_string(db_config) -> str:
-    """
-    Generate a formatted MongoDB connection string from a db_config object.
-
-    Args:
-        db_config: An object containing MongoDB connection parameters.
-
-    Returns:
-        str: A properly formatted MongoDB connection string.
-
-    """
-    # Handle MongoDB connection string variations
+    """Generate a formatted MongoDB connection string from a db_config object."""
     if db_config.db_host.startswith("mongodb://"):
         parts = db_config.db_host.replace("mongodb://", "").split(":")
         db_config.db_host = parts[0]
@@ -135,57 +209,38 @@ class MongoDBLoader:
     """MongoDB Loader class to upsert OntologyClass objects and insert OntologyRelation objects into MongoDB."""
 
     def __init__(self, schema_view: Optional[SchemaView] = None, mongo_client=None, db_name: Optional[str] = None):
-        """
-        Initialize MongoDB using LinkML-store's client, prioritizing environment variables for connection details.
-
-        :param schema_view: LinkML SchemaView for ontology
-        :param mongo_client: Optional existing MongoDB client to use instead of creating a new connection
-        :param db_name: Required database name when using an existing client
-        """
-        # Get database config from environment variables or fallback to MongoDBConfig defaults
+        """Initialize MongoDB using LinkML-store's client, prioritizing env vars."""
         self.db_config = MongoDBConfig()
         self.schema_view = schema_view
 
-        # If a MongoDB client was provided
         if mongo_client:
-            # Database name is required when passing a client
             if not db_name:
                 raise ValueError("Database name (db_name) is required when providing an existing MongoDB client")
-
-            # Set the database name and client in config
             self.db_config.db_name = db_name
             self.db_config.set_existing_client(mongo_client)
 
-        # Set up the database connection
-        if self.db_config.has_existing_client():
-            # Use the existing MongoDB client
-            logger.info("Using existing MongoDB client")
+        # The raw pymongo Database used by the bulk-write hot path. Created
+        # lazily when `_py_db` is first accessed unless an existing client was
+        # provided, in which case we set it up-front. Tests can inject a mock
+        # by assigning `loader._py_db = mock`.
+        self._py_db_value = None
+        self._py_client: Optional[PyMongoClient] = None
 
-            # Extract the connection details from the existing client
+        if self.db_config.has_existing_client():
+            logger.info("Using existing MongoDB client")
             existing_client = self.db_config.existing_client
-            # The host_string should contain the actual host and port
             host_string = existing_client.address[0]
             port = existing_client.address[1]
-
-            # Create a handle using the actual connection details and the provided db_name
             self.handle = f"mongodb://{host_string}:{port}/{self.db_config.db_name}"
             logger.info(f"Using existing client connection: {self.handle}")
-
-            # Create a Client using the handle
             self.client = Client(handle=self.handle)
-
-            # Access the mongodb database implementation
             db = self.client.attach_database(handle=self.handle)
-
-            # Replace the native client with our existing one
-            # This will make all MongoDB operations use our existing client
             mongodb_db = db
             mongodb_db._native_client = self.db_config.existing_client
             mongodb_db._native_db = self.db_config.existing_client[self.db_config.db_name]
-
             self.db = db
+            self._py_db_value = self.db_config.existing_client[self.db_config.db_name]
         else:
-            # Create a new connection using the connection string
             self.handle = get_mongo_connection_string(self.db_config)
             logger.info(f"MongoDB connection string: {self.handle}")
             self.client = Client(handle=self.handle)
@@ -193,55 +248,80 @@ class MongoDBLoader:
 
         logger.info(f"Connected to MongoDB: {self.db}")
 
+    @property
+    def _py_db(self):
+        """
+        Raw pymongo Database for hot-path bulk operations (lazily constructed).
+
+        We bypass linkml_store for the class/relation bulk-upsert path because
+        ``linkml_store.api.stores.mongodb.mongodb_collection.upsert`` iterates
+        per-item with ``find_one`` followed by ``update_one`` or ``insert_one``,
+        costing 2N round trips for N documents. That dominates the NCBITaxon
+        load (~2.7M classes + ~55M relations would take hours). Upstream issue
+        tracking a possible bulk-write path: https://github.com/linkml/linkml-store/issues/77 .
+        If linkml_store later grows a ``bulk_write``-backed upsert, the bypass
+        becomes a candidate for removal.
+        """
+        if self._py_db_value is None:
+            self._py_client = PyMongoClient(
+                host=self.db_config.db_host,
+                port=self.db_config.db_port,
+                username=self.db_config.db_user,
+                password=self.db_config.db_password,
+                authSource="admin",
+                directConnection=True,
+            )
+            self._py_db_value = self._py_client[self.db_config.db_name]
+        return self._py_db_value
+
+    @_py_db.setter
+    def _py_db(self, value):
+        """Allow tests (or callers reusing an external pymongo client) to inject a Database."""
+        self._py_db_value = value
+
     def upsert_ontology_data(
         self,
         ontology_classes: List[OntologyClass],
         ontology_relations: List[OntologyRelation],
         class_collection_name: str = "ontology_class_set",
         relation_collection_name: str = "ontology_relation_set",
+        report_mode: str = "compared",
     ):
         """
-        Upsert ontology terms, clear/re-populate ontology relations, handle obsolescence, and manage hierarchy changes.
+        Bulk-upsert ontology classes and relations.
 
-        :param ontology_classes: A list of OntologyClass objects to upsert.
-        :param ontology_relations: A list of OntologyRelation objects to upsert.
-        :param class_collection_name: MongoDB collection name for ontology classes.
-        :param relation_collection_name: MongoDB collection name for ontology relations.
-        :return: A tuple of three reports: class updates, class insertions, and relation insertions.
+        :param report_mode: One of 'compared' (default; preserves no-change skip
+            via batched pre-reads), 'upsert' (no pre-read, max throughput),
+            or 'off' (no report tracking; lowest memory).
+        :return: tuple of three `Report` objects (class updates, class inserts, relation inserts).
         """
-        # Use default collection names if not specified
+        if report_mode not in VALID_REPORT_MODES:
+            raise ValueError(f"Unknown report_mode {report_mode!r}; expected one of {VALID_REPORT_MODES}")
 
-        # Get the collections (they should already exist and have indexes from initialization)
+        # Schema-aware setup via linkml_store; also ensures indexes exist.
         class_collection = self.db.create_collection(class_collection_name, recreate_if_exists=False)
         relation_collection = self.db.create_collection(relation_collection_name, recreate_if_exists=False)
-
         class_collection.index("id", unique=False, name="ontology_class_index")
         relation_collection.index(["subject", "predicate", "object"], unique=False, name="ontology_relation_index")
 
-        # Step 1: Upsert ontology terms
-        updates_report, insertions_report, insertions_report_relations = [], [], []
         ontology_fields = [field.name for field in fields(OntologyClass)]
 
-        # Step 1.1: Handle obsolete terms
+        # Obsolete subset is small; keep the pre-existing linkml_store path.
         obsolete_terms = [obj.id for obj in ontology_classes if getattr(obj, "is_obsolete", False)]
         _handle_obsolete_terms(obsolete_terms, class_collection, relation_collection)
 
-        # Step 1.2: Upsert ontology classes
-        for obj in ontology_classes:
-            was_updated, report_row = _upsert_ontology_class(obj, class_collection, ontology_fields)
-            if was_updated and report_row:
-                updates_report.append(report_row)
-            elif not was_updated and report_row:
-                insertions_report.append(report_row)
+        # Hot-path bulk upserts via raw pymongo collections.
+        py_class = self._py_db[class_collection_name]
+        py_relation = self._py_db[relation_collection_name]
 
-        # Step 2: Upsert relations
-        for relation in ontology_relations:
-            report_data = _upsert_relation(relation, relation_collection)
-            if report_data:
-                insertions_report_relations.append(report_data)
+        insertions_report, updates_report = _bulk_upsert_classes(
+            py_class, ontology_classes, ontology_fields, report_mode
+        )
+        insertions_report_relations = _bulk_upsert_relations(py_relation, ontology_relations, report_mode)
 
         logging.info(
-            f"Finished upserting ontology data: {len(ontology_classes)} classes, {len(ontology_relations)} relations."
+            f"Finished upserting ontology data: {len(ontology_classes)} classes, "
+            f"{len(ontology_relations)} relations (report_mode={report_mode!r})."
         )
         return (
             Report("update", updates_report, ontology_fields),

--- a/src/ontology_loader/ontology_load_controller.py
+++ b/src/ontology_loader/ontology_load_controller.py
@@ -83,7 +83,7 @@ class OntologyLoaderController:
 
         # Update data
         updates_report, insertions_report, insert_relations_report = db_manager.upsert_ontology_data(
-            ontology_classes_relations, ontology_relations
+            ontology_classes_relations, ontology_relations, report_mode=self.report_mode
         )
 
         # Optionally write job reports

--- a/src/ontology_loader/ontology_load_controller.py
+++ b/src/ontology_loader/ontology_load_controller.py
@@ -28,6 +28,7 @@ class OntologyLoaderController:
         generate_reports: bool = True,
         mongo_client=None,
         db_name: str = None,
+        report_mode: str = "compared",
     ):
         """
         Set the parameters for the OntologyLoader.
@@ -38,6 +39,8 @@ class OntologyLoaderController:
             generate_reports: Whether to generate reports (default: True)
             mongo_client: Optional existing MongoDB client to use instead of creating a new connection
             db_name: Database name to use with existing client (required when mongo_client is provided)
+            report_mode: 'compared' (default; preserves no-change skip), 'upsert' (max throughput),
+                or 'off' (no report tracking). See `MongoDBLoader.upsert_ontology_data`.
 
         """
         self.source_ontology = source_ontology
@@ -45,6 +48,7 @@ class OntologyLoaderController:
         self.generate_reports = generate_reports
         self.mongo_client = mongo_client
         self.db_name = db_name
+        self.report_mode = report_mode
 
         # Validate that db_name is provided when mongo_client is provided
         if self.mongo_client and not self.db_name:

--- a/tests/test_mock_mongodb_loader.py
+++ b/tests/test_mock_mongodb_loader.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock
 import pytest
 from nmdc_schema.nmdc import OntologyClass, OntologyRelation
 
-from ontology_loader.mongodb_loader import MongoDBLoader, Report, _handle_obsolete_terms
+from ontology_loader.mongodb_loader import (
+    MongoDBLoader,
+    Report,
+    _handle_obsolete_terms,
+)
 from ontology_loader.utils import load_yaml_from_package
 
 
@@ -21,35 +25,69 @@ def mock_mongo_client():
     return MagicMock()
 
 
-@pytest.fixture()
-def mock_mongo_loader(schema_view):
-    """Mock MongoDBLoader to prevent actual database interactions."""
-    loader = MongoDBLoader(schema_view)
-    loader.client = MagicMock()
-    loader.db = MagicMock()
-    loader.db.get_collection = MagicMock()
-    return loader
-
-
 @pytest.fixture
 def mock_db():
-    """
-    Mock database.
-
-    :return: Mock database.
-    """
+    """Mock linkml_store database used for obsolete-term handling."""
     db = MagicMock()
     db.create_collection.return_value = MagicMock()
     return db
 
 
 @pytest.fixture
-def mock_ontology_classes():
+def mock_py_db_factory():
     """
-    Mock ontology classes.
+    Return a factory that builds a MagicMock acting as a pymongo Database.
 
-    :return: List of OntologyClass objects.
+    Default behavior:
+        - `<db>[name].find({...})` returns iter([]) (no existing docs)
+        - `<db>[name].bulk_write(ops, ...)` returns a BulkWriteResult-like
+          mock whose `upserted_ids` covers every op index (all inserts).
+    Tests can override per-collection behavior via the returned helpers.
     """
+
+    def make(find_results=None, upserted_all=True):
+        """
+        Build a mock pymongo Database with configurable find/bulk_write responses.
+
+        :param find_results: mapping of collection_name -> list of existing docs
+            returned by ``find``. Defaults to empty for any collection.
+        :param upserted_all: whether bulk_write returns all-inserted by default.
+        """
+        find_results = find_results or {}
+        collection_cache: dict = {}
+
+        def _collection_factory(name):
+            if name in collection_cache:
+                return collection_cache[name]
+            collection = MagicMock()
+
+            def _find(query):
+                return iter(find_results.get(name, []))
+
+            collection.find.side_effect = _find
+
+            def _bulk_write(ops, ordered=False):
+                result = MagicMock()
+                if upserted_all:
+                    result.upserted_ids = {i: f"oid-{i}" for i in range(len(ops))}
+                else:
+                    result.upserted_ids = {}
+                return result
+
+            collection.bulk_write.side_effect = _bulk_write
+            collection_cache[name] = collection
+            return collection
+
+        py_db = MagicMock()
+        py_db.__getitem__.side_effect = _collection_factory
+        return py_db
+
+    return make
+
+
+@pytest.fixture
+def mock_ontology_classes():
+    """Mock ontology classes."""
     return [
         OntologyClass(id="ONT:001", name="Term1", type="nmdc:OntologyClass"),
         OntologyClass(id="ONT:002", name="Term2", type="nmdc:OntologyClass"),
@@ -58,11 +96,7 @@ def mock_ontology_classes():
 
 @pytest.fixture
 def mock_ontology_relations():
-    """
-    Mock ontology relations.
-
-    :return: List of OntologyRelation objects.
-    """
+    """Mock ontology relations."""
     return [
         OntologyRelation(subject="ONT:001", predicate="related_to", object="ONT:002", type="nmdc:OntologyRelation"),
         OntologyRelation(subject="ONT:002", predicate="part_of", object="ONT:003", type="nmdc:OntologyRelation"),
@@ -71,11 +105,7 @@ def mock_ontology_relations():
 
 @pytest.fixture
 def mock_obsolete_classes():
-    """
-    Mock ontology classes with obsolete terms.
-
-    :return: List of OntologyClass objects.
-    """
+    """Mock ontology classes with obsolete terms."""
     return [
         OntologyClass(id="ONT:001", name="Term1", type="nmdc:OntologyClass"),
         OntologyClass(id="ONT:002", name="Term2", type="nmdc:OntologyClass", is_obsolete=True),
@@ -84,164 +114,99 @@ def mock_obsolete_classes():
 
 
 def test_init_with_existing_client(mock_mongo_client):
-    """
-    Test initializing MongoDBLoader with an existing MongoDB client.
-
-    :param mock_mongo_client: Mock MongoDB client.
-    """
-    # Create a MongoDBLoader with an existing client and db_name
+    """Initializing MongoDBLoader with an existing MongoDB client stores it on the config."""
     loader = MongoDBLoader(mongo_client=mock_mongo_client, db_name="test_db")
 
-    # Verify the client was stored in the config
     assert loader.db_config.has_existing_client()
     assert loader.db_config.existing_client == mock_mongo_client
     assert loader.db_config.db_name == "test_db"
-
-    # Check that we're using the provided client in the MongoDB database
     assert loader.db._native_client == mock_mongo_client
 
 
-def test_upsert_new_ontology_data(mock_db, mock_ontology_classes, mock_ontology_relations):
-    """
-    Test upserting new ontology data.
-
-    :param mock_db: Mock database.
-    :param mock_ontology_classes: Mock ontology classes.
-    :param mock_ontology_relations: Mock ontology relations.
-    """
+def test_upsert_new_ontology_data(mock_db, mock_py_db_factory, mock_ontology_classes, mock_ontology_relations):
+    """All-new classes and relations land in the inserts reports under 'compared' mode."""
     loader = MongoDBLoader()
     loader.db = mock_db
-    class_collection = mock_db.create_collection.return_value
-
-    mock_query_result = MagicMock()
-    mock_query_result.rows = []
-    mock_query_result.num_rows = 0  # Ensuring num_rows behaves like an integer
-
-    class_collection.find.return_value = mock_query_result  # Mocking find() response
+    loader._py_db = mock_py_db_factory()  # default: no existing docs, all inserts
 
     report = loader.upsert_ontology_data(mock_ontology_classes, mock_ontology_relations)
 
-    assert isinstance(report[0], Report)  # Class updates report
-    assert isinstance(report[1], Report)  # Class insertions report
-    assert isinstance(report[2], Report)  # Relation insertions report
-    assert len(report[1].records) == len(mock_ontology_classes)  # All classes inserted
-    assert len(report[2].records) == len(mock_ontology_relations)  # All relations inserted
+    assert isinstance(report[0], Report)
+    assert isinstance(report[1], Report)
+    assert isinstance(report[2], Report)
+    assert len(report[0].records) == 0  # no updates
+    assert len(report[1].records) == len(mock_ontology_classes)  # all classes inserted
+    assert len(report[2].records) == len(mock_ontology_relations)  # all relations inserted
 
 
-def test_upsert_existing_ontology_data(mock_db, mock_ontology_classes):
-    """
-    Test upserting existing ontology data.
-
-    :param mock_db: Mock database.
-    :param mock_ontology_classes: Mock ontology classes.
-    """
+def test_upsert_existing_ontology_data(mock_db, mock_py_db_factory, mock_ontology_classes):
+    """When every input class has a matching existing doc with different fields, they all go to updates."""
+    existing_docs = [
+        {"id": "ONT:001", "name": "OldTerm1", "type": "nmdc:OntologyClass"},
+        {"id": "ONT:002", "name": "OldTerm2", "type": "nmdc:OntologyClass"},
+    ]
     loader = MongoDBLoader()
     loader.db = mock_db
-    class_collection = mock_db.create_collection.return_value
-
-    existing_doc = {"id": "ONT:001", "name": "OldTerm", "type": "nmdc:OntologyClass"}
-
-    mock_query_result = MagicMock()
-    mock_query_result.rows = [existing_doc]
-    mock_query_result.num_rows = 1  # Ensuring num_rows behaves like an integer
-
-    class_collection.find.return_value = mock_query_result  # Mocking find() response
+    loader._py_db = mock_py_db_factory(find_results={"ontology_class_set": existing_docs})
 
     report = loader.upsert_ontology_data(mock_ontology_classes, [])
-    assert len(report[0].records) == 2  # One record should be updated
-    assert len(report[1].records) == 0  # One record should be inserted (new class)
+
+    assert len(report[0].records) == 2  # both classes updated (name differs)
+    assert len(report[1].records) == 0  # no inserts
 
 
-def test_handle_disappearing_relations(mock_db, mock_ontology_classes, mock_ontology_relations):
-    """
-    Test handling of disappearing relations.
-
-    :param mock_db: Mock database.
-    :param mock_ontology_classes: Mock ontology classes.
-    :param mock_ontology_relations: Mock ontology relations.
-    """
+def test_upsert_with_report_mode_off(mock_db, mock_py_db_factory, mock_ontology_classes, mock_ontology_relations):
+    """`report_mode='off'` should produce empty report lists and still call bulk_write."""
     loader = MongoDBLoader()
     loader.db = mock_db
-    relation_collection = mock_db.create_collection.return_value
+    loader._py_db = mock_py_db_factory()
 
-    mock_query_result = MagicMock()
-    mock_query_result.rows = [
-        {
-            "subject": "ONT:001",
-            "predicate": "entailed_isa_partof_closure",
-            "object": "ONT:002",
-            "type": "nmdc:OntologyRelation",
-        },
-        {
-            "subject": "ONT:002",
-            "predicate": "entailed_isa_partof_closure",
-            "object": "ONT:003",
-            "type": "nmdc:OntologyRelation",
-        },
-    ]
-    mock_query_result.num_rows = 2  # Ensuring num_rows behaves like an integer
+    report = loader.upsert_ontology_data(mock_ontology_classes, mock_ontology_relations, report_mode="off")
 
-    relation_collection.find.return_value = mock_query_result  # Mocking find() response
-    relation_collection.upsert = MagicMock()  # Mock upsert method
+    assert len(report[0].records) == 0
+    assert len(report[1].records) == 0
+    assert len(report[2].records) == 0
+    # bulk_write was invoked for both collections
+    assert loader._py_db["ontology_class_set"].bulk_write.called
+    assert loader._py_db["ontology_relation_set"].bulk_write.called
 
-    updated_relations = [
-        OntologyRelation(subject="ONT:001", predicate="related_to", object="ONT:003", type="nmdc:OntologyRelation")
-        # Changed relation
-    ]
 
-    def mock_upsert(data, filter_fields, update_fields=None):
-        """
-        Simulate relation updates.
+def test_upsert_with_report_mode_upsert(mock_db, mock_py_db_factory, mock_ontology_classes):
+    """`report_mode='upsert'` skips the pre-read and classifies via BulkWriteResult."""
+    loader = MongoDBLoader()
+    loader.db = mock_db
+    loader._py_db = mock_py_db_factory()  # all inserts
 
-        :param data: Data to upsert.
-        :param filter_fields: Fields to filter on.
-        :param update_fields: Fields to update.
-        """
-        for obj in data:
-            if "subject" in obj:
-                for ontology_class in mock_ontology_classes:
-                    if ontology_class.id == obj["subject"]:
-                        ontology_class.relations = [
-                            OntologyRelation(
-                                subject=obj["subject"],
-                                predicate=obj["predicate"],
-                                object=obj["object"],
-                                type="nmdc:OntologyRelation",
-                            )
-                        ]
+    report = loader.upsert_ontology_data(mock_ontology_classes, [], report_mode="upsert")
 
-    relation_collection.upsert.side_effect = mock_upsert  # Simulate relation updates
+    # No pre-read should have happened
+    assert not loader._py_db["ontology_class_set"].find.called
+    assert len(report[1].records) == len(mock_ontology_classes)
 
-    loader.upsert_ontology_data(mock_ontology_classes, updated_relations)
 
-    # Ensure upsert was called
-    relation_collection.upsert.assert_called()
+def test_upsert_rejects_unknown_report_mode(mock_db, mock_py_db_factory, mock_ontology_classes):
+    """An unrecognized report_mode raises ValueError before any DB call."""
+    loader = MongoDBLoader()
+    loader.db = mock_db
+    loader._py_db = mock_py_db_factory()
 
-    # Verify old relations were replaced
-    assert len(mock_ontology_classes[0].relations) == 1
-    assert mock_ontology_classes[0].relations[0].object == "ONT:003"
+    with pytest.raises(ValueError, match="report_mode"):
+        loader.upsert_ontology_data(mock_ontology_classes, [], report_mode="bogus")
 
 
 def test_handle_obsolete_terms_function(mock_db):
-    """
-    Test the _handle_obsolete_terms function directly.
-
-    :param mock_db: Mock database.
-    """
+    """`_handle_obsolete_terms` marks terms obsolete and clears their relations."""
     class_collection = mock_db.create_collection.return_value
     relation_collection = mock_db.create_collection.return_value
 
-    # Create a proper OntologyClass object
     term_obj = OntologyClass(id="ONT:001", name="Term1", type="nmdc:OntologyClass", is_obsolete=False)
-    term_obj.relations = ["some_relation"]  # Add relations attribute
+    term_obj.relations = ["some_relation"]
 
-    # Set up the find method to return the term_obj
     mock_query_result = MagicMock()
     mock_query_result.rows = [term_obj]
     mock_query_result.num_rows = 1
     class_collection.find.return_value = mock_query_result
 
-    # Capture what gets passed to upsert to verify changes
     upserted_data = None
 
     def capture_upsert(data, filter_fields, update_fields=None):
@@ -250,72 +215,48 @@ def test_handle_obsolete_terms_function(mock_db):
 
     class_collection.upsert.side_effect = capture_upsert
 
-    # Test with list of obsolete terms
     obsolete_terms = ["ONT:001", "ONT:002"]
     _handle_obsolete_terms(obsolete_terms, class_collection, relation_collection)
 
-    # Function creates a new dict from the original object, so the original stays unchanged
-    # But we can check what was passed to upsert
     assert upserted_data is not None, "No data was passed to upsert"
-    assert upserted_data["is_obsolete"] is True, "Term was not marked as obsolete"
-    assert upserted_data["relations"] == [], "Relations were not cleared"
-
-    # Verify class collection upsert was called
+    assert upserted_data["is_obsolete"] is True
+    assert upserted_data["relations"] == []
     class_collection.upsert.assert_called()
-
-    # Verify relation collection had delete called
     relation_collection.delete.assert_called_with(
         {"$or": [{"subject": {"$in": obsolete_terms}}, {"object": {"$in": obsolete_terms}}]}
     )
 
 
-def test_upsert_ontology_data_with_obsolete_terms(mock_db, mock_obsolete_classes, mock_ontology_relations):
-    """
-    Test upserting ontology data with obsolete terms.
-
-    :param mock_db: Mock database.
-    :param mock_obsolete_classes: Mock ontology classes with obsolete terms.
-    :param mock_ontology_relations: Mock ontology relations.
-    """
+def test_upsert_ontology_data_with_obsolete_terms(
+    mock_db, mock_py_db_factory, mock_obsolete_classes, mock_ontology_relations
+):
+    """`upsert_ontology_data` invokes obsolete handling on linkml_store and bulk writes on pymongo."""
     loader = MongoDBLoader()
     loader.db = mock_db
+    loader._py_db = mock_py_db_factory()
+
     class_collection = mock_db.create_collection.return_value
     relation_collection = mock_db.create_collection.return_value
 
-    # Since we're going to check multiple calls to find with different params,
-    # we need a more sophisticated mock that can return different results
+    # Obsolete handling reads each obsolete term via linkml_store find; return empty for both.
     def mock_find(criteria):
-        # Return empty result for any query
-        mock_result = MagicMock()
-        mock_result.rows = []
-        mock_result.num_rows = 0
-        return mock_result
+        result = MagicMock()
+        result.rows = []
+        result.num_rows = 0
+        return result
 
     class_collection.find.side_effect = mock_find
-
-    # Setup captured data for upserting
-    upserted_data = []
-
-    def capture_upsert(data, filter_fields, update_fields=None):
-        nonlocal upserted_data
-        if data and isinstance(data, list):
-            upserted_data.extend(data)
-
-    class_collection.upsert.side_effect = capture_upsert
-
-    # Configure relation collection delete method
     relation_collection.delete = MagicMock()
 
-    # Run the upsert function
     loader.upsert_ontology_data(mock_obsolete_classes, mock_ontology_relations)
 
-    # Verify obsolete terms were handled
-    obsolete_terms = ["ONT:002", "ONT:003"]  # These are marked as obsolete in mock_obsolete_classes
+    obsolete_terms = ["ONT:002", "ONT:003"]
     relation_collection.delete.assert_any_call(
         {"$or": [{"subject": {"$in": obsolete_terms}}, {"object": {"$in": obsolete_terms}}]}
     )
-
-    # Verify class collection find was called for correct term lookups
-    # The _handle_obsolete_terms function should look up each obsolete term
     for term_id in obsolete_terms:
         class_collection.find.assert_any_call({"id": term_id})
+
+    # Class bulk-write went through pymongo with all three input classes.
+    py_class = loader._py_db["ontology_class_set"]
+    assert py_class.bulk_write.called


### PR DESCRIPTION
## Why

`MongoDBLoader.upsert_ontology_data` previously called `linkml_store.upsert([single_doc], ...)` once per class and once per relation, plus a per-class `find({id: ...})` pre-read in `_upsert_ontology_class`. linkml_store's mongodb backend internally adds *another* `find_one` per item before the actual write. Result: ~3 round trips per document, dominating any load whose class+relation total exceeds a few tens of thousands.

Empirical measurement on a partial NCBITaxon load (2026-05-19, local Mongo):

| Collection size at start | Sustained class upsert rate (pre-refactor) |
|---|---:|
| ~22k (UBERON-scale) | ~4,750 ops/sec |
| 270k → 1.09M (NCBITaxon partial) | ~1,000 ops/sec, steady |

At NCBITaxon scale (~2.7M classes + ~55M closure relations) the per-item path extrapolates to many hours of wall time.

## What

- New module-level helpers `_bulk_upsert_classes` and `_bulk_upsert_relations` build `UpdateOne(..., upsert=True)` operations and submit them via pymongo's `bulk_write` in batches of 1k (`DEFAULT_BULK_BATCH_SIZE`).
- `MongoDBLoader.upsert_ontology_data` accepts a new `report_mode` parameter:
  - `compared` (default) — batched pre-read; reports only docs that actually changed. Preserves the original no-change-skip semantic at per-batch (rather than per-doc) granularity.
  - `upsert` — no pre-read; bulk-writes every doc and classifies inserts vs updates from `BulkWriteResult.upserted_ids`. Maximum throughput.
  - `off` — bulk-writes every doc; suppresses report tracking entirely. Lowest memory.
- New CLI option `--report-mode {compared,upsert,off}` and matching parameter on `OntologyLoaderController`.
- `_handle_obsolete_terms` is unchanged — the obsolete subset is small enough that the per-item path is not a bottleneck.
- `MongoDBLoader._py_db` is now a lazy property so tests can inject a mock without triggering a live pymongo connection at construction time.

## Why bypass linkml_store

`linkml_store.api.stores.mongodb.mongodb_collection.upsert` iterates per-item with `find_one` followed by `update_one`/`insert_one`. There is no `bulk_write` path today. Upstream issue filed at https://github.com/linkml/linkml-store/issues/77. The in-file comment on `MongoDBLoader._py_db` documents the rationale and links the upstream issue.

## Verification

- 11 previously-passing tests still pass; 3 new tests cover `report_mode='upsert'`, `report_mode='off'`, and invalid-mode rejection (13 total, 8 skipped on environments without live Mongo creds).
- `make lint` is clean after the formatter pass.
- End-to-end NCBITaxon smoke run pending against a local Mongo — empirical before/after throughput numbers will be added as a follow-up comment when that completes.