### PR TITLE
Read MONGO_* env vars in test_linkml_store_client_connections (closes #22)

### DIFF
--- a/tests/test_linkml_store_client_connections.py
+++ b/tests/test_linkml_store_client_connections.py
@@ -6,11 +6,13 @@ import pytest
 from linkml_store.api.client import Client
 from pymongo import MongoClient
 
-# MongoDB Connection Parameters
-MONGO_HOST = "localhost"
-MONGO_PORT = 27022
-MONGO_DB = "nmdc"  # Database where you want to insert/update
-MONGO_USER = "admin"
+# MongoDB connection parameters — read from environment to match the rest of
+# the test suite (e.g. tests/test_ontology_class_null_values.py:12-16) and
+# the loader itself (src/ontology_loader/mongo_db_config.py:23-27). See #22.
+MONGO_HOST = os.getenv("MONGO_HOST", "localhost")
+MONGO_PORT = int(os.getenv("MONGO_PORT", "27017"))
+MONGO_DB = os.getenv("MONGO_DBNAME", "nmdc")
+MONGO_USER = os.getenv("MONGO_USERNAME", "admin")
 MONGO_PASSWORD = os.getenv("MONGO_PASSWORD", "")
 AUTH_DB = "admin"  # Authentication database
 


### PR DESCRIPTION
## Why

`tests/test_linkml_store_client_connections.py:10-13` hardcoded MONGO_HOST / MONGO_PORT / MONGO_DB / MONGO_USER, only reading MONGO_PASSWORD from env. As a result, developers who enabled the live-DB tests by setting MONGO_PASSWORD (per the README at lines 128-130) got a confusing `Connection refused (localhost:27022)` failure because their local Mongo was on 27017 (the standard mongod port) or 27018 (the README's Docker recipe at line 16).

Discovered while running #10's PR through the test suite with `local/.env.localhost` sourced — 19 of 21 tests passed against the real local Mongo; this one couldn't.

## What

Match the env-reading pattern already used in `tests/test_ontology_class_null_values.py:12-16` and `src/ontology_loader/mongo_db_config.py:23-27`. Default port becomes 27017 (standard mongod) instead of the unexplained 27022. The `@pytest.mark.skipif` decorators are unchanged, so CI behavior is preserved: the tests still skip when `MONGO_PASSWORD` is unset.

Closes #22.