### PR TITLE
Add --force-refresh/--no-force-refresh to control pystow cache (closes #13)

### DIFF
--- a/src/ontology_loader/cli.py
+++ b/src/ontology_loader/cli.py
@@ -14,24 +14,36 @@ logger = logging.getLogger(__name__)
 @click.option("--source-ontology", default="envo", help="Lowercase ontology prefix, e.g., envo, go, uberon, etc.")
 @click.option("--output-directory", default=None, help="Output directory for reporting, default is /tmp")
 @click.option("--generate-reports", default=True, help="Generate reports")
-def cli(source_ontology, output_directory, generate_reports):
+@click.option(
+    "--force-refresh/--no-force-refresh",
+    default=True,
+    show_default=True,
+    help=(
+        "Whether to wipe the cached pystow directory and re-download the semsql sqlite from S3. "
+        "Default (true) preserves prior behavior: every run starts fresh. "
+        "Use --no-force-refresh for fast local iteration when the cached artifact is acceptable."
+    ),
+)
+def cli(source_ontology, output_directory, generate_reports, force_refresh):
     """
     CLI entry point for the ontology loader.
 
     :param source_ontology: Lowercase ontology prefix, e.g., envo, go, uberon, etc.
     :param output_directory: Output directory for reporting, default is /tmp
     :param generate_reports: Generate reports or not, default is True
+    :param force_refresh: If True (default), wipe the cached pystow directory and re-download
+        the semsql sqlite from S3; if False, reuse the cached artifact when present.
 
     Set the parameters for the connection to mongodb in the environment variables MONGO_HOST, MONGO_PORT,
     MONGO_USER, MONGO_PASSWORD, MONGO_DB.
     """
     logger.info(f"Processing ontology: {source_ontology}")
 
-    # Initialize the MongoDB Loader
     loader = OntologyLoaderController(
         source_ontology=source_ontology,
         output_directory=output_directory,
         generate_reports=generate_reports,
+        force_refresh=force_refresh,
     )
     loader.run_ontology_loader()
 

--- a/src/ontology_loader/ontology_load_controller.py
+++ b/src/ontology_loader/ontology_load_controller.py
@@ -28,6 +28,7 @@ class OntologyLoaderController:
         generate_reports: bool = True,
         mongo_client=None,
         db_name: str = None,
+        force_refresh: bool = True,
     ):
         """
         Set the parameters for the OntologyLoader.
@@ -38,6 +39,8 @@ class OntologyLoaderController:
             generate_reports: Whether to generate reports (default: True)
             mongo_client: Optional existing MongoDB client to use instead of creating a new connection
             db_name: Database name to use with existing client (required when mongo_client is provided)
+            force_refresh: If True (default), wipe any cached pystow artifact for this ontology
+                and re-download from S3. Set False to reuse an existing cached download.
 
         """
         self.source_ontology = source_ontology
@@ -45,6 +48,7 @@ class OntologyLoaderController:
         self.generate_reports = generate_reports
         self.mongo_client = mongo_client
         self.db_name = db_name
+        self.force_refresh = force_refresh
 
         # Validate that db_name is provided when mongo_client is provided
         if self.mongo_client and not self.db_name:
@@ -55,7 +59,7 @@ class OntologyLoaderController:
         # Load Schema View
         nmdc_sv = load_yaml_from_package("nmdc_schema", "nmdc_materialized_patterns.yaml")
         # Initialize the Ontology Processor
-        processor = OntologyProcessor(self.source_ontology)
+        processor = OntologyProcessor(self.source_ontology, force_refresh=self.force_refresh)
 
         # Process ontology terms and return a list of OntologyClass dicts produced by linkml json dumper as dict
         ontology_classes = processor.get_terms_and_metadata()

--- a/src/ontology_loader/ontology_processor.py
+++ b/src/ontology_loader/ontology_processor.py
@@ -42,14 +42,20 @@ class OntologyProcessor:
 
     """Ontology Processor class to process ontology terms and relations."""
 
-    def __init__(self, ontology: str):
+    def __init__(self, ontology: str, force_refresh: bool = True):
         """
         Initialize the OntologyProcessor with a given SQLite ontology.
 
         :param ontology: The ontology prefix (e.g., "envo", "go", "uberon", etc.)
+        :param force_refresh: If True (default), remove any cached pystow
+            directory for this ontology and re-download the semsql sqlite
+            artifact from S3. Set to False to reuse a previously-downloaded
+            artifact (e.g. for fast local iteration); the download/extract
+            steps then become no-ops when the files already exist.
 
         """
         self.ontology = ontology
+        self.force_refresh = force_refresh
         self.ontology_db_path = self.download_and_prepare_ontology()
         self.adapter = get_adapter(f"sqlite:{self.ontology_db_path}")
         self.adapter.precompute_lookups()  # Optimize lookups
@@ -64,10 +70,13 @@ class OntologyProcessor:
         # Get the ontology-specific pystow directory
         source_ontology_module = pystow.module(self.ontology).base  # Example: ~/.pystow/envo
 
-        # If the directory exists, remove it and all its contents
-        if source_ontology_module.exists():
+        # Force-refresh wipes any cached artifact so pystow re-downloads.
+        # When False, an existing .db.gz / .db is reused as-is (no network).
+        if self.force_refresh and source_ontology_module.exists():
             logger.info(f"Removing existing pystow directory for {self.ontology}: {source_ontology_module}")
             shutil.rmtree(source_ontology_module)
+        elif source_ontology_module.exists():
+            logger.info(f"Reusing cached pystow directory for {self.ontology}: {source_ontology_module}")
 
         # Define ontology URL
         ontology_db_url_prefix = "https://s3.amazonaws.com/bbop-sqlite/"


### PR DESCRIPTION
## Why

`OntologyProcessor.download_and_prepare_ontology` unconditionally `rmtree`s the pystow directory at the start of every run, forcing a fresh S3 download of the semsql sqlite artifact every single time. For NCBITaxon that's ~7 minutes of wall time even when nothing has changed upstream. For local iteration on the loader code, paying that cost on every run is pure waste.

## What

- New boolean `force_refresh` on `OntologyProcessor` and `OntologyLoaderController` (default `True`, preserving prior behavior).
- New CLI flag `--force-refresh/--no-force-refresh` (default `force-refresh`).
- When `False`, the `rmtree` is skipped; `pystow.ensure()` short-circuits the download because the `.db.gz` is already present, and the gzip-extract step is already a no-op when the `.db` exists.

## Default behavior

Default stays `True` so the existing weekly Dagster job in nmdc-runtime (which calls `OntologyLoaderController(...)` without specifying refresh) keeps its current freshness guarantee with no upstream change required.

## Verification

`make test` still passes (11 passed, 8 skipped, no regression). The `test_ontology_processor` tests use the default (`force_refresh=True`) so they continue to exercise the download/extract path.

Closes #13.