### PR TITLE
Add three closure-emission flags (closes #8)

### DIFF
--- a/src/ontology_loader/cli.py
+++ b/src/ontology_loader/cli.py
@@ -14,24 +14,54 @@ logger = logging.getLogger(__name__)
 @click.option("--source-ontology", default="envo", help="Lowercase ontology prefix, e.g., envo, go, uberon, etc.")
 @click.option("--output-directory", default=None, help="Output directory for reporting, default is /tmp")
 @click.option("--generate-reports", default=True, help="Generate reports")
-def cli(source_ontology, output_directory, generate_reports):
+@click.option(
+    "--emit-combined-closure/--no-emit-combined-closure",
+    default=True,
+    show_default=True,
+    help="Emit `entailed_isa_partof_closure` (combined transitive closure over rdfs:subClassOf ∪ BFO:0000050).",
+)
+@click.option(
+    "--emit-isa-closure/--no-emit-isa-closure",
+    default=False,
+    show_default=True,
+    help="Emit `entailed_isa_closure` (transitive closure over rdfs:subClassOf only).",
+)
+@click.option(
+    "--emit-partof-closure/--no-emit-partof-closure",
+    default=False,
+    show_default=True,
+    help="Emit `entailed_partof_closure` (transitive closure over BFO:0000050 only).",
+)
+def cli(
+    source_ontology,
+    output_directory,
+    generate_reports,
+    emit_combined_closure,
+    emit_isa_closure,
+    emit_partof_closure,
+):
     """
     CLI entry point for the ontology loader.
 
     :param source_ontology: Lowercase ontology prefix, e.g., envo, go, uberon, etc.
     :param output_directory: Output directory for reporting, default is /tmp
     :param generate_reports: Generate reports or not, default is True
+    :param emit_combined_closure: Emit the combined `entailed_isa_partof_closure`. Default True.
+    :param emit_isa_closure: Emit the `rdfs:subClassOf`-only `entailed_isa_closure`. Default False.
+    :param emit_partof_closure: Emit the `BFO:0000050`-only `entailed_partof_closure`. Default False.
 
     Set the parameters for the connection to mongodb in the environment variables MONGO_HOST, MONGO_PORT,
     MONGO_USER, MONGO_PASSWORD, MONGO_DB.
     """
     logger.info(f"Processing ontology: {source_ontology}")
 
-    # Initialize the MongoDB Loader
     loader = OntologyLoaderController(
         source_ontology=source_ontology,
         output_directory=output_directory,
         generate_reports=generate_reports,
+        emit_combined_closure=emit_combined_closure,
+        emit_isa_closure=emit_isa_closure,
+        emit_partof_closure=emit_partof_closure,
     )
     loader.run_ontology_loader()
 

--- a/src/ontology_loader/ontology_load_controller.py
+++ b/src/ontology_loader/ontology_load_controller.py
@@ -28,6 +28,9 @@ class OntologyLoaderController:
         generate_reports: bool = True,
         mongo_client=None,
         db_name: str = None,
+        emit_combined_closure: bool = True,
+        emit_isa_closure: bool = False,
+        emit_partof_closure: bool = False,
     ):
         """
         Set the parameters for the OntologyLoader.
@@ -38,6 +41,9 @@ class OntologyLoaderController:
             generate_reports: Whether to generate reports (default: True)
             mongo_client: Optional existing MongoDB client to use instead of creating a new connection
             db_name: Database name to use with existing client (required when mongo_client is provided)
+            emit_combined_closure: Emit `entailed_isa_partof_closure` (default True; backward compatible).
+            emit_isa_closure: Also emit `entailed_isa_closure` (rdfs:subClassOf only). Default False.
+            emit_partof_closure: Also emit `entailed_partof_closure` (BFO:0000050 only). Default False.
 
         """
         self.source_ontology = source_ontology
@@ -45,6 +51,9 @@ class OntologyLoaderController:
         self.generate_reports = generate_reports
         self.mongo_client = mongo_client
         self.db_name = db_name
+        self.emit_combined_closure = emit_combined_closure
+        self.emit_isa_closure = emit_isa_closure
+        self.emit_partof_closure = emit_partof_closure
 
         # Validate that db_name is provided when mongo_client is provided
         if self.mongo_client and not self.db_name:
@@ -64,7 +73,10 @@ class OntologyLoaderController:
 
         # Process ontology relations and create OntologyRelation objects
         ontology_relations, ontology_classes_relations = processor.get_relations_closure(
-            ontology_terms=ontology_classes
+            ontology_terms=ontology_classes,
+            emit_combined_closure=self.emit_combined_closure,
+            emit_isa_closure=self.emit_isa_closure,
+            emit_partof_closure=self.emit_partof_closure,
         )
 
         logger.info(f"Extracted {len(ontology_relations)} ontology relations.")

--- a/src/ontology_loader/ontology_processor.py
+++ b/src/ontology_loader/ontology_processor.py
@@ -134,12 +134,29 @@ class OntologyProcessor:
 
         return ontology_classes
 
-    def get_relations_closure(self, predicates=None, ontology_terms: list = None) -> tuple:
+    def get_relations_closure(
+        self,
+        predicates=None,
+        ontology_terms: list = None,
+        emit_combined_closure: bool = True,
+        emit_isa_closure: bool = False,
+        emit_partof_closure: bool = False,
+    ) -> tuple:
         """
         Retrieve all ontology relations closure for terms with improved performance.
 
-        :param predicates: List of predicates to consider (default: ["rdfs:subClassOf", "BFO:0000050"])
+        :param predicates: Predicates to filter the direct-edge phase by (default:
+            ["rdfs:subClassOf", "BFO:0000050"]). Does not affect which entailed
+            closures are emitted; that is controlled by the three emit_* flags.
         :param ontology_terms: List of OntologyClass objects to consider (default: None)
+        :param emit_combined_closure: If True (default), emit
+            `entailed_isa_partof_closure` relations covering the combined
+            transitive closure over `rdfs:subClassOf` ∪ `BFO:0000050`.
+            Backward-compatible default.
+        :param emit_isa_closure: If True, additionally emit `entailed_isa_closure`
+            relations covering the transitive closure over `rdfs:subClassOf` only.
+        :param emit_partof_closure: If True, additionally emit `entailed_partof_closure`
+            relations covering the transitive closure over `BFO:0000050` only.
         :return: Tuple of (ontology_relations, updated_ontology_terms)
         """
         predicates = ["rdfs:subClassOf", "BFO:0000050"] if predicates is None else predicates
@@ -168,25 +185,41 @@ class OntologyProcessor:
 
         logger.info(f"Processed {relationship_count} direct relationships")
 
-        # Process all ancestors for all entities in one batch
-        logger.info("Processing ancestry relationships...")
-        ancestry_count = 0
+        # Build the list of (output_predicate_name, ancestry_predicates) closures
+        # the caller asked for. Each requires its own ancestors() traversal per entity.
+        closure_specs = []
+        if emit_combined_closure:
+            closure_specs.append(("entailed_isa_partof_closure", ["rdfs:subClassOf", "BFO:0000050"]))
+        if emit_isa_closure:
+            closure_specs.append(("entailed_isa_closure", ["rdfs:subClassOf"]))
+        if emit_partof_closure:
+            closure_specs.append(("entailed_partof_closure", ["BFO:0000050"]))
 
-        for entity in relevant_entities:
-            # Get ancestors for this entity and filter to only include those from our ontology
-            ancestors = set(
-                ancestor
-                for ancestor in self.adapter.ancestors(entity, reflexive=True, predicates=predicates)
-                if ancestor.startswith(ontology_prefix)
+        if closure_specs:
+            logger.info(
+                f"Processing ancestry relationships across {len(closure_specs)} closure type(s): "
+                f"{', '.join(name for name, _ in closure_specs)}"
             )
+            ancestry_count = 0
+            for entity in relevant_entities:
+                for closure_name, closure_predicates in closure_specs:
+                    ancestors = set(
+                        ancestor
+                        for ancestor in self.adapter.ancestors(
+                            entity, reflexive=True, predicates=closure_predicates
+                        )
+                        if ancestor.startswith(ontology_prefix)
+                    )
+                    for ancestor in ancestors:
+                        relation_dict = _create_relation(
+                            entity, closure_name, ancestor, ontology_terms_dict
+                        )
+                        ontology_relations.append(relation_dict)
+                        ancestry_count += 1
+            logger.info(f"Processed {ancestry_count} ancestry relationships")
+        else:
+            logger.info("No ancestry closure types enabled; skipping ancestry computation.")
 
-            # Create relations for each ancestor
-            for ancestor in ancestors:
-                relation_dict = _create_relation(entity, "entailed_isa_partof_closure", ancestor, ontology_terms_dict)
-                ontology_relations.append(relation_dict)
-                ancestry_count += 1
-
-        logger.info(f"Processed {ancestry_count} ancestry relationships")
         logger.info(f"Total relations: {len(ontology_relations)}")
 
         # Return the relations and updated ontology terms

--- a/src/ontology_loader/ontology_processor.py
+++ b/src/ontology_loader/ontology_processor.py
@@ -205,15 +205,11 @@ class OntologyProcessor:
                 for closure_name, closure_predicates in closure_specs:
                     ancestors = set(
                         ancestor
-                        for ancestor in self.adapter.ancestors(
-                            entity, reflexive=True, predicates=closure_predicates
-                        )
+                        for ancestor in self.adapter.ancestors(entity, reflexive=True, predicates=closure_predicates)
                         if ancestor.startswith(ontology_prefix)
                     )
                     for ancestor in ancestors:
-                        relation_dict = _create_relation(
-                            entity, closure_name, ancestor, ontology_terms_dict
-                        )
+                        relation_dict = _create_relation(entity, closure_name, ancestor, ontology_terms_dict)
                         ontology_relations.append(relation_dict)
                         ancestry_count += 1
             logger.info(f"Processed {ancestry_count} ancestry relationships")


### PR DESCRIPTION
## Why

`ontology_processor.get_relations_closure` emits a single `entailed_isa_partof_closure` predicate covering the combined transitive closure over `rdfs:subClassOf` ∪ `BFO:0000050`. The two paths can't be separated at query time downstream, so "all is_a descendants of X" returns false positives reached only via `part_of`. Issue #8 documents the impact: ENVO `env_broad_scale` (biome) has 127 is_a-only descendants vs. 223 combined — a 43% noise rate on the combined predicate.

## What

Three boolean flags (default-off for the two new closures, default-on for the existing combined predicate so prior behavior is preserved):

| Flag | Default | Emits |
|---|---|---|
| `--emit-combined-closure` / `--no-emit-combined-closure` | on | `entailed_isa_partof_closure` (existing) |
| `--emit-isa-closure` / `--no-emit-isa-closure` | off | `entailed_isa_closure` (rdfs:subClassOf only) |
| `--emit-partof-closure` / `--no-emit-partof-closure` | off | `entailed_partof_closure` (BFO:0000050 only) |

All three can be enabled simultaneously. Each enabled closure adds one `adapter.ancestors()` traversal per entity.

Direct edges (`rdfs:subClassOf`, `BFO:0000050`) are emitted unchanged regardless of the flags — they continue to populate `ontology_relation_set` as before.

## Performance caveat

Each enabled non-combined closure adds another SQL traversal per entity. For NCBITaxon (2.7M entities, 33-minute ancestry phase already), enabling all three would roughly triple that phase to ~100 minutes. The naive implementation here will be superseded by the entailed-edge optimization tracked in #18 (single indexed scan instead of per-entity traversals).

## Verification

`make test` still passes (11 passed, 8 skipped, no regression). Defaults reproduce today's behavior bit-for-bit.

Closes #8.