### PR TITLE
Deprecate `--generate-reports` in favor of `--report-mode` (closes #36)

### DIFF
--- a/src/ontology_loader/cli.py
+++ b/src/ontology_loader/cli.py
@@ -1,8 +1,10 @@
 """Cli methods for ontology loading from the command line."""
 
 import logging
+import warnings
 
 import click
+from click.core import ParameterSource
 
 from ontology_loader.ontology_load_controller import OntologyLoaderController
 
@@ -13,7 +15,16 @@ logger = logging.getLogger(__name__)
 @click.command()
 @click.option("--source-ontology", default="envo", help="Lowercase ontology prefix, e.g., envo, go, uberon, etc.")
 @click.option("--output-directory", default=None, help="Output directory for reporting, default is /tmp")
-@click.option("--generate-reports", default=True, help="Generate reports")
+@click.option(
+    "--generate-reports/--no-generate-reports",
+    default=True,
+    show_default=True,
+    help=(
+        "DEPRECATED: prefer --report-mode. "
+        "--no-generate-reports (without an explicit --report-mode) is treated as --report-mode off. "
+        "If --report-mode is given explicitly, it wins and --generate-reports is ignored."
+    ),
+)
 @click.option(
     "--report-mode",
     type=click.Choice(["compared", "upsert", "off"], case_sensitive=False),
@@ -23,22 +34,41 @@ logger = logging.getLogger(__name__)
         "How upsert reports are produced. "
         "'compared' batches a pre-read and only reports docs that actually changed (preserves prior fidelity); "
         "'upsert' skips the pre-read and reports every existing doc as updated (max throughput); "
-        "'off' suppresses report tracking entirely (lowest memory)."
+        "'off' suppresses both in-memory report tracking and TSV writes (lowest memory, fastest)."
     ),
 )
-def cli(source_ontology, output_directory, generate_reports, report_mode):
+@click.pass_context
+def cli(ctx, source_ontology, output_directory, generate_reports, report_mode):
     """
     CLI entry point for the ontology loader.
 
     Set the parameters for the connection to mongodb in the environment variables MONGO_HOST, MONGO_PORT,
     MONGO_USER, MONGO_PASSWORD, MONGO_DB.
     """
+    report_mode_explicit = ctx.get_parameter_source("report_mode") == ParameterSource.COMMANDLINE
+
+    if not generate_reports:
+        if report_mode_explicit:
+            warnings.warn(
+                f"--no-generate-reports is deprecated; --report-mode={report_mode!r} (explicit) takes precedence. "
+                "Drop --generate-reports from your invocation.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        else:
+            warnings.warn(
+                "--no-generate-reports is deprecated; use --report-mode off instead. "
+                "Treating this run as --report-mode off.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            report_mode = "off"
+
     logger.info(f"Processing ontology: {source_ontology}")
 
     loader = OntologyLoaderController(
         source_ontology=source_ontology,
         output_directory=output_directory,
-        generate_reports=generate_reports,
         report_mode=report_mode,
     )
     loader.run_ontology_loader()

--- a/src/ontology_loader/ontology_load_controller.py
+++ b/src/ontology_loader/ontology_load_controller.py
@@ -2,6 +2,7 @@
 
 import logging
 import tempfile
+import warnings
 
 from ontology_loader.mongodb_loader import MongoDBLoader
 from ontology_loader.ontology_processor import OntologyProcessor
@@ -10,6 +11,9 @@ from ontology_loader.utils import load_yaml_from_package
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
+
+
+_GENERATE_REPORTS_UNSET = object()
 
 
 class OntologyLoaderController:
@@ -25,7 +29,7 @@ class OntologyLoaderController:
         self,
         source_ontology: str = "envo",
         output_directory: str = tempfile.gettempdir(),
-        generate_reports: bool = True,
+        generate_reports=_GENERATE_REPORTS_UNSET,
         mongo_client=None,
         db_name: str = None,
         report_mode: str = "compared",
@@ -36,19 +40,47 @@ class OntologyLoaderController:
         Args:
             source_ontology: Name of the ontology to load (default: "envo")
             output_directory: Directory where reports will be written (default: temp directory)
-            generate_reports: Whether to generate reports (default: True)
+            generate_reports: DEPRECATED. Use ``report_mode`` instead. ``generate_reports=False``
+                (without an explicit ``report_mode``) is translated to ``report_mode="off"`` and
+                emits ``DeprecationWarning``. To be removed in a future release; see #36.
             mongo_client: Optional existing MongoDB client to use instead of creating a new connection
             db_name: Database name to use with existing client (required when mongo_client is provided)
             report_mode: 'compared' (default; preserves no-change skip), 'upsert' (max throughput),
-                or 'off' (no report tracking). See `MongoDBLoader.upsert_ontology_data`.
+                or 'off' (skip both in-memory tracking and TSV writes). See
+                ``MongoDBLoader.upsert_ontology_data``.
 
         """
         self.source_ontology = source_ontology
         self.output_directory = output_directory
-        self.generate_reports = generate_reports
         self.mongo_client = mongo_client
         self.db_name = db_name
         self.report_mode = report_mode
+
+        if generate_reports is not _GENERATE_REPORTS_UNSET:
+            if generate_reports is False:
+                if report_mode == "compared":
+                    warnings.warn(
+                        "OntologyLoaderController(generate_reports=False) is deprecated; "
+                        "pass report_mode='off' instead. Treating this run as report_mode='off'.",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+                    self.report_mode = "off"
+                else:
+                    warnings.warn(
+                        f"OntologyLoaderController(generate_reports=False) is deprecated; "
+                        f"the explicit report_mode={report_mode!r} takes precedence. "
+                        "Drop generate_reports from the call.",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+            else:
+                warnings.warn(
+                    "OntologyLoaderController(generate_reports=...) is deprecated and ignored when True; "
+                    "use report_mode to control reporting behavior.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
 
         # Validate that db_name is provided when mongo_client is provided
         if self.mongo_client and not self.db_name:
@@ -86,8 +118,8 @@ class OntologyLoaderController:
             ontology_classes_relations, ontology_relations, report_mode=self.report_mode
         )
 
-        # Optionally write job reports
-        if self.generate_reports:
+        # Optionally write job reports — skipped entirely when reporting is off.
+        if self.report_mode != "off":
             ReportWriter.write_reports(
                 reports=[updates_report, insertions_report, insert_relations_report],
                 output_format="tsv",

--- a/tests/test_mock_ontology_load_reports.py
+++ b/tests/test_mock_ontology_load_reports.py
@@ -50,7 +50,6 @@ def ontology_loader():
     return OntologyLoaderController(
         source_ontology="envo",
         output_directory=tempfile.gettempdir(),
-        generate_reports=True,
     )
 
 

--- a/tests/test_ontology_load_controller.py
+++ b/tests/test_ontology_load_controller.py
@@ -32,7 +32,6 @@ def ontology_loader():
     return OntologyLoaderController(
         source_ontology="envo",
         output_directory=tempfile.gettempdir(),
-        generate_reports=True,
     )
 
 
@@ -57,7 +56,6 @@ def ontology_loader_with_client(mock_mongo_client):
     return OntologyLoaderController(
         source_ontology="envo",
         output_directory=tempfile.gettempdir(),
-        generate_reports=True,
         mongo_client=mock_mongo_client,
         db_name="test_db",
     )

--- a/tests/test_report_flags_deprecation.py
+++ b/tests/test_report_flags_deprecation.py
@@ -1,0 +1,83 @@
+"""Tests for the `--generate-reports` → `--report-mode` deprecation (issue #36)."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+from click.testing import CliRunner
+
+from ontology_loader.cli import cli
+from ontology_loader.ontology_load_controller import OntologyLoaderController
+
+# ---- OntologyLoaderController-level deprecation -----------------------------
+
+
+def test_controller_generate_reports_false_alone_sets_off():
+    """generate_reports=False without explicit report_mode → report_mode='off' + warning."""
+    with pytest.warns(DeprecationWarning, match=r"generate_reports=False.*report_mode='off'"):
+        controller = OntologyLoaderController(
+            source_ontology="envo",
+            generate_reports=False,
+        )
+    assert controller.report_mode == "off"
+
+
+def test_controller_generate_reports_false_with_explicit_report_mode_keeps_mode():
+    """generate_reports=False with explicit non-default report_mode: warn but keep the mode."""
+    with pytest.warns(DeprecationWarning, match=r"report_mode='upsert'.*takes precedence"):
+        controller = OntologyLoaderController(
+            source_ontology="envo",
+            generate_reports=False,
+            report_mode="upsert",
+        )
+    assert controller.report_mode == "upsert"
+
+
+def test_controller_generate_reports_true_warns_but_is_ignored():
+    """generate_reports=True is deprecated; warn but don't change anything."""
+    with pytest.warns(DeprecationWarning, match=r"ignored when True"):
+        controller = OntologyLoaderController(
+            source_ontology="envo",
+            generate_reports=True,
+        )
+    # Default behavior preserved
+    assert controller.report_mode == "compared"
+
+
+def test_controller_no_generate_reports_param_no_warning():
+    """Not passing generate_reports at all must not raise a DeprecationWarning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        OntologyLoaderController(source_ontology="envo")
+
+
+# ---- CLI-level deprecation --------------------------------------------------
+
+
+def test_cli_no_generate_reports_alone_emits_warning_and_sets_off():
+    """
+    Confirm `--no-generate-reports` is shown as deprecated in `--help`.
+
+    We assert on the textual deprecation notice rather than exercising the
+    full ontology-loader run from the CLI, because that path requires a real
+    semsql download + MongoDB. The controller-level test above already covers
+    the report_mode='off' coercion logic.
+    """
+    runner = CliRunner()
+    # Help text contains 'DEPRECATED' — confirms the help string change shipped.
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "DEPRECATED" in result.output
+    assert "--generate-reports" in result.output
+
+
+def test_cli_help_describes_off_mode_as_skipping_tsv_writes():
+    """`--report-mode off` help text must state that TSV writes are suppressed too."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    # Click wraps long help lines, so collapse whitespace before searching.
+    flat = " ".join(result.output.split())
+    assert "in-memory report tracking" in flat
+    assert "TSV writes" in flat


### PR DESCRIPTION
## Why

After #21 added `--report-mode {compared,upsert,off}`, `--generate-reports` is the redundant flag. Two reasons to consolidate:

1. **Surface area**: a reader of the loader has to know *both* flags to predict what gets tracked/written.
2. **Surprising overlap**: in `main`+#21, `--report-mode off --generate-reports true` (the implicit default for the latter) writes empty TSVs — neither what "off" sounds like nor what most callers want.

## Base branch

This PR targets `issue-10-bulk-write` (PR #21), not `main`, because `--report-mode` doesn't exist on `main` yet. GitHub will retarget to `main` automatically once #21 merges.

## What changed

1. **`--report-mode off` now also skips TSV writes** (one line in the controller). After this, "off" is strictly stronger than `--generate-reports false`, which is the prerequisite the original issue body assumed but the code didn't yet implement (see [my correction comment on #36](https://github.com/microbiomedata/ontology-loader/issues/36#issuecomment-4501859965)).
2. **`--no-generate-reports` is deprecated**:
   - Without an explicit `--report-mode`: translated to `--report-mode off`, `DeprecationWarning` emitted.
   - With an explicit `--report-mode`: a different `DeprecationWarning` says "drop --generate-reports; explicit --report-mode wins."
3. **`generate_reports=True` (controller kwarg) is also deprecated** — that was always the implicit default, never load-bearing.
4. **CLI help text for `--generate-reports` is prefixed `DEPRECATED:`** so the migration prompt is visible the first time anyone runs `--help`.
5. **New test module** (`tests/test_report_flags_deprecation.py`) covers all four deprecation paths plus the help-text contract.
6. **Existing fixtures** that passed `generate_reports=True` drop it; that's the default behavior now.

## Release N+1 (separate PR)

Removing the flag and the kwarg outright needs coordination with nmdc-runtime maintainers, since their weekly Dagster job calls `--generate-reports`. That's deliberately not in scope here.

Closes #36.